### PR TITLE
Tier 2 performance optimizations

### DIFF
--- a/app/components/EventsCalendar.tsx
+++ b/app/components/EventsCalendar.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { DayPicker } from 'react-day-picker';
+import 'react-day-picker/style.css';
+
+interface Props {
+  /** Unix ms timestamps of every event date, precomputed on the server. */
+  eventTimestamps: number[];
+  /** YYYY-MM of the calendar's initial month. */
+  initialMonthKey: string;
+}
+
+function monthKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function dayKey(d: Date): string {
+  return `${monthKey(d)}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function formatLongDate(d: Date): string {
+  return d.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function formatMonthLabel(key: string): string {
+  const [y, m] = key.split('-').map(Number);
+  return new Date(y, m - 1, 1).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+export default function EventsCalendar({ eventTimestamps, initialMonthKey }: Props) {
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
+  const [displayMonth, setDisplayMonth] = useState<Date>(() => {
+    const [y, m] = initialMonthKey.split('-').map(Number);
+    return new Date(y, m - 1, 1);
+  });
+
+  // DayPicker needs Date objects. Reconstruct once from the serialized prop.
+  const eventDatesRef = useRef<Date[] | null>(null);
+  if (eventDatesRef.current === null) {
+    eventDatesRef.current = eventTimestamps.map((t) => new Date(t));
+  }
+
+  useEffect(() => {
+    const list = document.getElementById('events-list');
+    if (!list) return;
+
+    const cards = list.querySelectorAll<HTMLElement>('[data-event]');
+    const emptyMsg = list.querySelector<HTMLElement>('[data-empty-state]');
+
+    let shown = 0;
+    if (selectedDate) {
+      const key = dayKey(selectedDate);
+      cards.forEach((el) => {
+        const match = el.dataset.date === key;
+        el.classList.toggle('hidden', !match);
+        if (match) shown += 1;
+      });
+      if (emptyMsg) {
+        emptyMsg.textContent = `No events on ${formatLongDate(selectedDate)}`;
+      }
+    } else {
+      const key = monthKey(displayMonth);
+      const todayTs = new Date().setHours(0, 0, 0, 0);
+      cards.forEach((el) => {
+        const cardMonth = el.dataset.month;
+        const cardTs = Number(el.dataset.timestamp);
+        const match = cardMonth === key && cardTs >= todayTs;
+        el.classList.toggle('hidden', !match);
+        if (match) shown += 1;
+      });
+      if (emptyMsg) {
+        emptyMsg.textContent = `No events in ${formatMonthLabel(key)}`;
+      }
+    }
+
+    if (emptyMsg) emptyMsg.classList.toggle('hidden', shown > 0);
+  }, [selectedDate, displayMonth]);
+
+  return (
+    <div className="bg-warm-white rounded-2xl border border-border p-5 shadow-sm">
+      <DayPicker
+        mode="single"
+        selected={selectedDate}
+        onSelect={setSelectedDate}
+        month={displayMonth}
+        onMonthChange={setDisplayMonth}
+        modifiers={{ hasEvent: eventDatesRef.current }}
+        modifiersClassNames={{ hasEvent: 'rdp-has-event' }}
+      />
+      {selectedDate && (
+        <button
+          type="button"
+          onClick={() => setSelectedDate(undefined)}
+          className="mt-4 w-full text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-hover-bg border border-border rounded-lg py-2.5 transition-colors"
+        >
+          Clear filter
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/components/EventsCalendarClient.tsx
+++ b/app/components/EventsCalendarClient.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Suspense } from 'react';
+import dynamic from 'next/dynamic';
+
+const EventsCalendar = dynamic(() => import('./EventsCalendar'), {
+  ssr: false,
+});
+
+function Skeleton() {
+  return (
+    <div
+      aria-hidden
+      className="bg-warm-white rounded-2xl border border-border shadow-sm h-[380px]"
+    />
+  );
+}
+
+export default function EventsCalendarClient(props: {
+  eventTimestamps: number[];
+  initialMonthKey: string;
+}) {
+  return (
+    <Suspense fallback={<Skeleton />}>
+      <EventsCalendar {...props} />
+    </Suspense>
+  );
+}

--- a/app/components/EventsSection.tsx
+++ b/app/components/EventsSection.tsx
@@ -1,32 +1,9 @@
-'use client';
-
-import { useMemo, useState } from 'react';
 import Image from 'next/image';
-import { DayPicker } from 'react-day-picker';
-import 'react-day-picker/style.css';
-import {
-  events,
-  parseEventDate,
-  isSameDay,
-  getEventDates,
-  type EventItem,
-} from '@/data/events';
+import { events, type EventItem } from '@/data/events';
+import EventsCalendar from './EventsCalendarClient';
 
-function formatLongDate(d: Date): string {
-  return d.toLocaleDateString('en-US', {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-  });
-}
-
-function EventCard({ event }: { event: EventItem }) {
-  const eventDate = parseEventDate(event);
-  const monthLabel = eventDate.toLocaleDateString('en-US', { month: 'short' }).toUpperCase();
-  const dayLabel = eventDate.getDate();
-  const weekdayLabel = eventDate.toLocaleDateString('en-US', { weekday: 'long' });
-
-  const cardInner = (
+function EventCardContent({ event }: { event: EventItem }) {
+  return (
     <div className="bg-warm-white rounded-2xl overflow-hidden border border-border h-full flex flex-col">
       {event.image && (
         <div className="relative aspect-video">
@@ -42,10 +19,10 @@ function EventCard({ event }: { event: EventItem }) {
       <div className="p-5 sm:p-6 flex gap-4 flex-grow">
         <div className="flex flex-col items-center justify-start shrink-0 w-14 pt-1">
           <div className="text-[11px] font-semibold tracking-wider text-gold-bright uppercase">
-            {monthLabel}
+            {event.monthLabel}
           </div>
           <div className="font-serif text-3xl leading-none text-text-primary mt-0.5">
-            {dayLabel}
+            {event.dayLabel}
           </div>
         </div>
         <div className="flex flex-col flex-grow min-w-0 border-l border-border pl-4">
@@ -53,7 +30,7 @@ function EventCard({ event }: { event: EventItem }) {
             {event.title}
           </h3>
           <div className="text-xs text-text-secondary mt-1.5 flex flex-wrap gap-x-3">
-            <span>{weekdayLabel}</span>
+            <span>{event.weekdayLabel}</span>
             <span>{event.time}</span>
           </div>
           <p className="text-sm text-text-secondary mt-1">{event.location}</p>
@@ -62,48 +39,56 @@ function EventCard({ event }: { event: EventItem }) {
       </div>
     </div>
   );
+}
 
+function EventCardWrapper({ event, hidden }: { event: EventItem; hidden: boolean }) {
+  const className = hidden ? 'h-full hidden' : 'h-full';
   if (event.href) {
     return (
-      <a href={event.href} target="_blank" rel="noopener noreferrer" className="block h-full">
-        {cardInner}
+      <a
+        data-event
+        data-date={event.date}
+        data-month={event.monthKey}
+        data-timestamp={event.timestamp}
+        href={event.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`block ${className}`}
+      >
+        <EventCardContent event={event} />
       </a>
     );
   }
-  return cardInner;
+  return (
+    <div
+      data-event
+      data-date={event.date}
+      data-month={event.monthKey}
+      data-timestamp={event.timestamp}
+      className={className}
+    >
+      <EventCardContent event={event} />
+    </div>
+  );
 }
 
 export default function EventsSection() {
-  const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
-  const [displayMonth, setDisplayMonth] = useState<Date>(() => {
-    const now = new Date();
-    return new Date(now.getFullYear(), now.getMonth(), 1);
-  });
-
-  const eventDates = useMemo(() => getEventDates(), []);
-
-  const visibleEvents = useMemo(() => {
-    if (selectedDate) {
-      return events.filter((e) => isSameDay(parseEventDate(e), selectedDate));
-    }
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return events
-      .filter((e) => {
-        const d = parseEventDate(e);
-        if (d < today) return false;
-        return (
-          d.getFullYear() === displayMonth.getFullYear() &&
-          d.getMonth() === displayMonth.getMonth()
-        );
-      })
-      .sort((a, b) => parseEventDate(a).getTime() - parseEventDate(b).getTime());
-  }, [selectedDate, displayMonth]);
-
-  const monthLabel = displayMonth.toLocaleDateString('en-US', {
+  const now = new Date();
+  const todayTs = new Date(now).setHours(0, 0, 0, 0);
+  const initialMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const initialMonthLabel = now.toLocaleDateString('en-US', {
     month: 'long',
     year: 'numeric',
   });
+
+  const eventTimestamps = events.map((e) => e.timestamp);
+
+  const visibleOnFirstPaint = new Set(
+    events
+      .filter((e) => e.monthKey === initialMonthKey && e.timestamp >= todayTs)
+      .map((e) => e.id),
+  );
+  const anyVisible = visibleOnFirstPaint.size > 0;
 
   return (
     <section id="events" className="py-20 sm:py-28 px-4 bg-cream">
@@ -117,42 +102,32 @@ export default function EventsSection() {
 
         <div className="grid grid-cols-1 lg:grid-cols-[340px_1fr] gap-10 lg:gap-14">
           <div className="lg:sticky lg:top-28 self-start">
-            <div className="bg-warm-white rounded-2xl border border-border p-5 shadow-sm">
-              <DayPicker
-                mode="single"
-                selected={selectedDate}
-                onSelect={setSelectedDate}
-                month={displayMonth}
-                onMonthChange={setDisplayMonth}
-                modifiers={{ hasEvent: eventDates }}
-                modifiersClassNames={{ hasEvent: 'rdp-has-event' }}
-              />
-              {selectedDate && (
-                <button
-                  type="button"
-                  onClick={() => setSelectedDate(undefined)}
-                  className="mt-4 w-full text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-hover-bg border border-border rounded-lg py-2.5 transition-colors"
-                >
-                  Clear filter
-                </button>
-              )}
-            </div>
+            <EventsCalendar
+              eventTimestamps={eventTimestamps}
+              initialMonthKey={initialMonthKey}
+            />
           </div>
 
-          <div>
-            {visibleEvents.length === 0 ? (
-              <div className="text-center py-16 text-text-secondary">
-                {selectedDate
-                  ? `No events on ${formatLongDate(selectedDate)}`
-                  : `No events in ${monthLabel}`}
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-                {visibleEvents.map((event) => (
-                  <EventCard key={event.id} event={event} />
-                ))}
-              </div>
-            )}
+          <div id="events-list">
+            <div
+              data-empty-state
+              className={
+                anyVisible
+                  ? 'text-center py-16 text-text-secondary hidden'
+                  : 'text-center py-16 text-text-secondary'
+              }
+            >
+              No events in {initialMonthLabel}
+            </div>
+            <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+              {events.map((event) => (
+                <EventCardWrapper
+                  key={event.id}
+                  event={event}
+                  hidden={!visibleOnFirstPaint.has(event.id)}
+                />
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/data/events.ts
+++ b/data/events.ts
@@ -1,6 +1,6 @@
 import eventsData from './events.json';
 
-export interface EventItem {
+export interface RawEvent {
   id: string;
   title: string;
   date: string;
@@ -11,28 +11,29 @@ export interface EventItem {
   href?: string;
 }
 
-export const events: EventItem[] = eventsData as EventItem[];
-
-export function parseEventDate(event: EventItem): Date {
-  return new Date(event.date + 'T00:00:00');
+export interface EventItem extends RawEvent {
+  /** Unix ms timestamp, computed once at module load. */
+  timestamp: number;
+  /** YYYY-MM key for month filtering without Date objects. */
+  monthKey: string;
+  /** Display strings precomputed for server rendering. */
+  monthLabel: string;
+  dayLabel: number;
+  weekdayLabel: string;
 }
 
-export function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
+function enrich(raw: RawEvent): EventItem {
+  const d = new Date(raw.date + 'T00:00:00');
+  return {
+    ...raw,
+    timestamp: d.getTime(),
+    monthKey: `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`,
+    monthLabel: d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase(),
+    dayLabel: d.getDate(),
+    weekdayLabel: d.toLocaleDateString('en-US', { weekday: 'long' }),
+  };
 }
 
-export function getUpcomingEvents(list: EventItem[] = events): EventItem[] {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  return list
-    .filter((e) => parseEventDate(e) >= today)
-    .sort((a, b) => parseEventDate(a).getTime() - parseEventDate(b).getTime());
-}
-
-export function getEventDates(list: EventItem[] = events): Date[] {
-  return list.map(parseEventDate);
-}
+export const events: EventItem[] = (eventsData as RawEvent[])
+  .map(enrich)
+  .sort((a, b) => a.timestamp - b.timestamp);

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,10 @@
 const nextConfig = {
   images: {
     remotePatterns: [
-      { protocol: 'https', hostname: '**' },
+      { protocol: 'https', hostname: 'se-images.campuslabs.com' },
+      { protocol: 'https', hostname: 'images.lumacdn.com' },
+      { protocol: 'https', hostname: 'encrypted-tbn0.gstatic.com' },
+      { protocol: 'https', hostname: 'wwmt.com' },
     ],
   },
 };


### PR DESCRIPTION
## Summary

Tier 2 of the performance audit. Focused on shrinking the home page First Load JS by getting `react-day-picker` and the events data off the critical path.

- **Server/client split for `EventsSection`.** [app/components/EventsSection.tsx](app/components/EventsSection.tsx) is now a **server component** that pre-renders every event card with `data-event`, `data-date`, `data-month`, and `data-timestamp` attributes. No event JSX ships to the client. Initial visibility (current month, upcoming only) is handled with a `hidden` class applied at render time.
- **New client island, [app/components/EventsCalendar.tsx](app/components/EventsCalendar.tsx).** Holds the `DayPicker` + filter state. On change it imperatively queries `[data-event]` under `#events-list` and toggles `.hidden` to match the selected date or month. No React state flows through the card list, so card DOM is rendered exactly once.
- **Dynamic import with `ssr: false` behind Suspense, [app/components/EventsCalendarClient.tsx](app/components/EventsCalendarClient.tsx).** Tiny `'use client'` wrapper that `next/dynamic()`-imports the calendar and wraps it in `<Suspense>` with a 380px skeleton. Without the Suspense boundary Next 15 bails out to pure CSR for the whole tree (which is what caused the \"missing required error components\" error mid-development — fixed).
- **Precompute event dates, [data/events.ts](data/events.ts).** Events are enriched once at module load with `timestamp`, `monthKey`, `monthLabel`, `dayLabel`, `weekdayLabel`, and sorted by timestamp. Removed the per-render `parseEventDate` / `isSameDay` / `getEventDates` / `getUpcomingEvents` helpers — nothing needed them after the split.
- **Tightened `remotePatterns`, [next.config.js](next.config.js).** Wildcard `hostname: '**'` replaced with the four actual hosts used by `events.json`: `se-images.campuslabs.com`, `images.lumacdn.com`, `encrypted-tbn0.gstatic.com`, `wwmt.com`.

## Build output

```
Route (app)                                 Size  First Load JS
Pre-Tier-1 baseline:
┌ /                                      24.4 kB         135 kB
After Tier 1 (merged):
┌ /                                      24.0 kB         134 kB
After Tier 2:
┌ /                                      3.37 kB         114 kB
```

Home route: **24.0 kB to 3.37 kB**. First Load JS: **134 kB to 114 kB** (20 kB drop). `react-day-picker` + its CSS + the calendar component now live in a deferred chunk loaded after hydration.

## Architecture note

The client island talks to the server-rendered cards via DOM attributes + imperative `classList.toggle` rather than React state. Unusual, but correct here: card JSX is expensive (next/image + external links + text) and never changes, while the filter state is tiny. Pushing filtering through React would either re-render every card on every click (same cost as the old 'use client' version) or hoist the card markup into the island (same thing).

## Test plan

- [ ] `/` loads cleanly in dev and prod builds. No \"missing required error components\" or bailout errors.
- [ ] Events section shows the current month's upcoming events on first paint.
- [ ] Clicking a date on the calendar (that has a dot) filters cards to just that day.
- [ ] \"Clear filter\" button returns to current-month view.
- [ ] Navigating the calendar to a different month updates the card list. Empty month shows \"No events in <Month Year>\".
- [ ] Remote event images from Luma / CampusLabs still load (remotePatterns allowlist).
- [ ] Calendar hydration: brief skeleton then the DayPicker appears. Acceptable layout shift.

## Flagged but not fixed

- `metadataBase` warning (Tier 1 flag, still unresolved).
- Calendar skeleton height is a fixed 380px guess. Minor CLS possible if the actual DayPicker differs. Tighten if it's visible.
- Item 7 from the audit (replace `react-day-picker` with a hand-rolled calendar) intentionally skipped. After this PR the library is out of the critical path, so the ROI dropped sharply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)