### PR TITLE
Fix today's event being filtered as past

### DIFF
--- a/app/components/EventsCalendar.tsx
+++ b/app/components/EventsCalendar.tsx
@@ -68,11 +68,11 @@ export default function EventsCalendar({ eventTimestamps, initialMonthKey }: Pro
       }
     } else {
       const key = monthKey(displayMonth);
-      const todayTs = new Date().setHours(0, 0, 0, 0);
+      const todayStr = dayKey(new Date());
       cards.forEach((el) => {
         const cardMonth = el.dataset.month;
-        const cardTs = Number(el.dataset.timestamp);
-        const match = cardMonth === key && cardTs >= todayTs;
+        const cardDate = el.dataset.date ?? '';
+        const match = cardMonth === key && cardDate >= todayStr;
         el.classList.toggle('hidden', !match);
         if (match) shown += 1;
       });

--- a/app/components/EventsSection.tsx
+++ b/app/components/EventsSection.tsx
@@ -74,8 +74,11 @@ function EventCardWrapper({ event, hidden }: { event: EventItem; hidden: boolean
 
 export default function EventsSection() {
   const now = new Date();
-  const todayTs = new Date(now).setHours(0, 0, 0, 0);
-  const initialMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  const initialMonthKey = `${yyyy}-${mm}`;
+  const todayStr = `${yyyy}-${mm}-${dd}`;
   const initialMonthLabel = now.toLocaleDateString('en-US', {
     month: 'long',
     year: 'numeric',
@@ -85,7 +88,7 @@ export default function EventsSection() {
 
   const visibleOnFirstPaint = new Set(
     events
-      .filter((e) => e.monthKey === initialMonthKey && e.timestamp >= todayTs)
+      .filter((e) => e.monthKey === initialMonthKey && e.date >= todayStr)
       .map((e) => e.id),
   );
   const anyVisible = visibleOnFirstPaint.size > 0;


### PR DESCRIPTION
## Summary

Events dated today were being hidden from the current-month view. Tier 2 compared `event.timestamp >= new Date().setHours(0, 0, 0, 0)`, which should have matched but was apparently off due to a timezone or DST edge case. Swapped both the server pre-filter and the client island filter to ISO `"YYYY-MM-DD"` string comparison, which is timezone-independent and inclusive.

- [app/components/EventsSection.tsx](app/components/EventsSection.tsx): first-paint filter now uses `event.date >= todayStr`.
- [app/components/EventsCalendar.tsx](app/components/EventsCalendar.tsx): island's month-view filter now uses `el.dataset.date >= todayStr`.

## Test plan

- [ ] Event dated today appears in the current-month list.
- [ ] Past events still hidden.
- [ ] Selecting a specific date still works for past dates with events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)