### PR TITLE
calendar-new-month-fix

### DIFF
--- a/app/components/EventsCalendar.tsx
+++ b/app/components/EventsCalendar.tsx
@@ -7,8 +7,6 @@ import 'react-day-picker/style.css';
 interface Props {
   /** YYYY-MM-DD strings for every event, rebuilt as local-midnight Dates on the client. */
   eventDates: string[];
-  /** YYYY-MM of the calendar's initial month. */
-  initialMonthKey: string;
 }
 
 function monthKey(d: Date): string {
@@ -35,11 +33,13 @@ function formatMonthLabel(key: string): string {
   });
 }
 
-export default function EventsCalendar({ eventDates, initialMonthKey }: Props) {
+export default function EventsCalendar({ eventDates }: Props) {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
+  // This component is client-only (`ssr: false`), so `new Date()` here is the
+  // viewer's real "now" — not the build-time date the server component would see.
   const [displayMonth, setDisplayMonth] = useState<Date>(() => {
-    const [y, m] = initialMonthKey.split('-').map(Number);
-    return new Date(y, m - 1, 1);
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), 1);
   });
 
   // DayPicker needs Date objects in local time so the right calendar cell lights up.

--- a/app/components/EventsCalendarClient.tsx
+++ b/app/components/EventsCalendarClient.tsx
@@ -18,7 +18,6 @@ function Skeleton() {
 
 export default function EventsCalendarClient(props: {
   eventDates: string[];
-  initialMonthKey: string;
 }) {
   return (
     <Suspense fallback={<Skeleton />}>

--- a/app/components/EventsSection.tsx
+++ b/app/components/EventsSection.tsx
@@ -105,10 +105,7 @@ export default function EventsSection() {
 
         <div className="grid grid-cols-1 lg:grid-cols-[340px_1fr] gap-10 lg:gap-14">
           <div className="lg:sticky lg:top-28 self-start">
-            <EventsCalendar
-              eventDates={eventDates}
-              initialMonthKey={initialMonthKey}
-            />
+            <EventsCalendar eventDates={eventDates} />
           </div>
 
           <div id="events-list">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,11 @@ import BroncoBuildIt from './components/BroncoBuildIt';
 import EventsSection from './components/EventsSection';
 import RotatingBadge from './components/RotatingBadge';
 
+// EventsSection derives "today" from `new Date()`. Without revalidation that's
+// frozen at build time, so the server-rendered events list would stay stuck on
+// whatever month the site was last deployed in. Refresh the static HTML hourly.
+export const revalidate = 3600;
+
 export default function Home() {
   return (
     <div className="min-h-screen flex flex-col bg-cream">


### PR DESCRIPTION
## Problem

The events calendar on the landing page always opened on whatever month the site was last deployed in (April), instead of the visitor's current month.

## Cause

`EventsSection` is a server component, so its `const now = new Date()` is evaluated **at build time**, not per-visit. It derived `initialMonthKey` from that and passed it down to the (client-only) `EventsCalendar` as the calendar's starting month — freezing the calendar on the build date.

## Fix

- `EventsCalendar` now derives its initial month from `new Date()` directly. It's rendered with `ssr: false`, so this runs in the browser with the viewer's real clock.
- Dropped the now-unused `initialMonthKey` prop from `EventsCalendar` / `EventsCalendarClient`.
- Added `export const revalidate = 3600` to the home page so the server-rendered events list / empty-state label also stay current instead of frozen at build time (the client effect still corrects them precisely once JS loads; this just keeps the pre-hydration HTML fresh).

## Verification

`npm run build` passes — types check, lint passes, all static pages generate. Route table confirms `/` now revalidates hourly while still being prerendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)